### PR TITLE
feat: add since option

### DIFF
--- a/date.js
+++ b/date.js
@@ -1,7 +1,10 @@
 const moment = require('moment');
 
+const parseAmount = (amount) =>
+    amount.startsWith('a') ? 1 : parseInt(matches[1], 10);
+
 const date = (input) => {
-    const matches = input.match(/(\d+) (\w+)( ago)?/);
+    const matches = input.match(/(\d+|an?) (\w+)( ago)?/);
     if (matches) {
         const unit = moment.normalizeUnits(matches[2]);
 
@@ -9,7 +12,9 @@ const date = (input) => {
             throw new Error('Could not parse date');
         }
 
-        return moment().subtract(matches[1], matches[2]);
+        const amount = parseAmount(matches[1]);
+
+        return moment().subtract(amount, matches[2]);
     }
 
     return moment(input);

--- a/date.js
+++ b/date.js
@@ -1,0 +1,18 @@
+const moment = require('moment');
+
+const date = (input) => {
+    const matches = input.match(/(\d+) (\w+)( ago)?/);
+    if (matches) {
+        const unit = moment.normalizeUnits(matches[2]);
+
+        if (!unit) {
+            throw new Error('Could not parse date');
+        }
+
+        return moment().subtract(matches[1], matches[2]);
+    }
+
+    return moment(input);
+};
+
+module.exports = date;

--- a/date.js
+++ b/date.js
@@ -1,7 +1,7 @@
 const moment = require('moment');
 
 const parseAmount = (amount) =>
-    amount.startsWith('a') ? 1 : parseInt(matches[1], 10);
+    amount.startsWith('a') ? 1 : parseInt(amount, 10);
 
 const date = (input) => {
     const matches = input.match(/(\d+|an?) (\w+)( ago)?/);

--- a/index.js
+++ b/index.js
@@ -1,14 +1,32 @@
 #!/usr/bin/env node
 
-const colors = require('colors');
+const { Command, Option } = require('commander');
 const process = require('process');
-
 const { displayLatestCommits } = require('./main');
+
+const version = require('./package.json').version;
+
+const date = require('./date');
+
+const sinceOption = (option) => {
+    return new Option(`--${option} <date>`, 'Show work after a specific date').argParser(date);
+};
+
+const program = new Command();
+
+program
+    .name('git-scrum')
+    .version(version)
+    .addOption(sinceOption('since'))
+    .addOption(sinceOption('after'))
+    .parse();
+
+const { since } = program.opts();
 
 try {
     displayLatestCommits({
         from: process.cwd(),
-        since: null
+        since: since
     });
 } catch (e) {
     console.log(e);

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ function displayLatestCommitsSince(since) {
             const latestCommits = commits.filter((commit) => since.isBefore(commit.date));
 
             if (latestCommits.length > 0) {
-                outputCommits(commits, branchName);
+                outputCommits(latestCommits, branchName);
             }
         });
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "colors": "^1.4.0",
+        "commander": "^9.4.1",
         "moment": "^2.29.0"
       },
       "bin": {
@@ -1812,6 +1813,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/component-emitter": {
@@ -8447,6 +8456,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
+      "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw=="
     },
     "component-emitter": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "colors": "^1.4.0",
+    "commander": "^9.4.1",
     "moment": "^2.29.0"
   },
   "bin": {
@@ -38,7 +39,9 @@
     "parserOptions": {
       "ecmaVersion": "latest"
     },
-    "plugins": ["jest"],
+    "plugins": [
+      "jest"
+    ],
     "rules": {}
   }
 }

--- a/tests/date.test.js
+++ b/tests/date.test.js
@@ -1,0 +1,35 @@
+const moment = require('moment');
+
+const date = require('../date');
+
+describe('when passing a duration', () => {
+    describe('when passing days', () => {
+        test('should return the correct date', () => {
+            const actual = date('3 days ago');
+
+            expect(moment().diff(actual, 'days')).toEqual(3);
+        });
+    });
+
+    describe('when passing weeks', () => {
+        const actual = date('3 week');
+
+        expect(moment().diff(actual, 'days')).toEqual(21);
+    });
+});
+
+describe('when passing a complete date', () => {
+    test('should parse it correctly', () => {
+        const actual = date('2022-10-16');
+
+        expect(moment('2022-10-16').isSame(actual)).toBeTruthy();
+    });
+});
+
+describe('when passing a partial date', () => {
+    test('should parse it correctly', () => {
+        const actual = date('2022');
+
+        expect(moment('2022-01-01').isSame(actual)).toBeTruthy();
+    });
+});


### PR DESCRIPTION
With this feature, we add an option to let the user decide since when he is interested in the latest commits.

This changeset also adds a new dependency, [`commander`](https://github.com/tj/commander.js/) to handle the command line parameters.

### Usage

#### Relative

```bash
$ git-scrum --since 'a week ago'
```

```bash
$ git-scrum --since '1 day ago'
```

#### Specific date

```bash
$ git-scrum --since '2022-10-01'
```

Really fixes #5